### PR TITLE
Adding connection with different domains

### DIFF
--- a/content/openstack-cpi.md
+++ b/content/openstack-cpi.md
@@ -149,7 +149,7 @@ Schema:
 
 * **default_volume_type** [String, optional]: sets volume type for persistent disks unless overridden in resource pool/VM Type. `cinder type-list` will return the available volume types. Example: `SSD`.
 
-Example with Keystone V3:
+Example with Keystone V3 and a single domain:
 
 ```yaml
 auth_url: http://pistoncloud.com:5000/v3
@@ -157,6 +157,19 @@ username: christopher
 api_key: QRoqsenPsNGX6
 project: Bosh
 domain: sample-domain
+region: RegionOne
+default_key_name: bosh
+default_security_groups: [bosh]
+```
+Example with Keystone V3 and a different domains for user and project:
+
+```yaml
+auth_url: http://pistoncloud.com:5000/v3
+username: christopher
+api_key: QRoqsenPsNGX6
+project: Bosh
+user_domain_name: user-domain
+project_domain_name: project-domain
 region: RegionOne
 default_key_name: bosh
 default_security_groups: [bosh]


### PR DESCRIPTION
An example is added to differentiate the connection to Openstack using a common domain and a different domains for user and project, according to the last changes made in the bosh-openstack-cpi-release.